### PR TITLE
Fixed group update

### DIFF
--- a/hvac/api/secrets_engines/identity.py
+++ b/hvac/api/secrets_engines/identity.py
@@ -815,6 +815,9 @@ class Identity(VaultApiBase):
             mount_point=mount_point,
             name=name,
         )
+        filtered = {k: v for k, v in params.items() if v is not None}
+        params.clear()
+        params.update(filtered)
         response = self._adapter.post(
             url=api_path,
             json=params,


### PR DESCRIPTION
When some values are None when calling Vault API, they are still considered set by the api, and therefore it creates a bug with conflicted keys defined